### PR TITLE
Updated rustc-serialize version to 0.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ Utilities for working with time-related functions in Rust.
 
 [dependencies.rustc-serialize]
 optional = true
-version = "0.1"
+version = "0.2"
 
 [build-dependencies]
 gcc = "0.1"


### PR DESCRIPTION
This was preventing compilation of downstream programs using newer versions of rustc-serialize with time.

Example errors:
```rust
warning: using multiple versions of crate `rustc-serialize`
/Users/Aaron/Documents/Programming/Rust/mailbot/src/main.rs:3:1: 3:51 note: used here
/Users/Aaron/Documents/Programming/Rust/mailbot/src/main.rs:3 extern crate "rustc-serialize" as rustc_serialize;
                                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
note: crate name: rustc-serialize
/Users/Aaron/Documents/Programming/Rust/mailbot/src/main.rs:2:1: 2:18 note: used here
/Users/Aaron/Documents/Programming/Rust/mailbot/src/main.rs:2 extern crate irc;
                                                              ^~~~~~~~~~~~~~~~~
note: crate name: rustc-serialize
/Users/Aaron/Documents/Programming/Rust/mailbot/src/main.rs:122:9: 122:23 error: type `time::Timespec` does not implement any method in scope named `encode`
/Users/Aaron/Documents/Programming/Rust/mailbot/src/main.rs:122         time: Timespec,
                                                                        ^~~~~~~~~~~~~~
/Users/Aaron/Documents/Programming/Rust/mailbot/src/main.rs:117:39: 117:53 note: in expansion of #[deriving(Encodable)]
/Users/Aaron/Documents/Programming/Rust/mailbot/src/main.rs:122:9: 122:23 note: expansion site
/Users/Aaron/Documents/Programming/Rust/mailbot/src/main.rs:117:23: 117:37 error: the trait `rustc-serialize::serialize::Decodable<__D, __E>` is not implemented for the type `time::Timespec`
/Users/Aaron/Documents/Programming/Rust/mailbot/src/main.rs:117     #[deriving(Clone, RustcDecodable, RustcEncodable)]
                                                                                      ^~~~~~~~~~~~~~
note: in expansion of #[deriving]
/Users/Aaron/Documents/Programming/Rust/mailbot/src/main.rs:117:5: 117:55 note: expansion site
error: aborting due to 2 previous errors
Could not compile `mailbot`.
```