### PR TITLE
fixes build for mac platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,9 +246,11 @@ pub fn precise_time_ns() -> u64 {
 
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     fn os_precise_time_ns() -> u64 {
-        let time = imp::mach_absolute_time();
-        let info = imp::info();
-        time * info.numer as u64 / info.denom as u64
+        unsafe {
+            let time = imp::mach_absolute_time();
+            let info = imp::info();
+            time * info.numer as u64 / info.denom as u64
+        }
     }
 
     #[cfg(not(any(windows, target_os = "macos", target_os = "ios")))]


### PR DESCRIPTION
Fixes the build for mac platforms. 

Currently errors with:

    src/lib.rs:249:20: 249:45 error: call to unsafe function requires unsafe function or block [E0133]
    src/lib.rs:249         let time = imp::mach_absolute_time();
                                      ^~~~~~~~~~~~~~~~~~~~~~~~~
    error: aborting due to previous error
    Could not compile `time`.