### PR TITLE
Remove inclusion of tchar.h

### DIFF
--- a/src/time_helpers.c
+++ b/src/time_helpers.c
@@ -25,7 +25,6 @@
 #include <windows.h>
 #include <wincrypt.h>
 #include <stdio.h>
-#include <tchar.h>
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
The dependency on tchar.h prevented build on windows for me. Removal of the inclusion does not appear to cause any problems. Unless this will cause other problems, I'd like to have it removed.