### PR TITLE
Fix build failure when cross-compiling to Android 21

### DIFF
--- a/src/time_helpers.c
+++ b/src/time_helpers.c
@@ -39,6 +39,9 @@
 // Gonk has this symbol, but Android doesn't
 #ifndef TARGET_OS_GONK
 #ifdef __ANDROID__
+
+#include <android/api-level.h>
+#if __ANDROID_API__ < 21
 static time_t timegm(struct tm *tm) {
     time_t ret;
     char *tz;
@@ -57,6 +60,7 @@ static time_t timegm(struct tm *tm) {
     tzset();
     return ret;
 }
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
See https://github.com/rust-lang/time/issues/71 :

.../time/src/time_helpers.c:42:15: error: static declaration of 'timegm' follows non-static declaration
 static time_t timegm(struct tm *tm) {
               ^
In file included from .../time/src/time_helpers.c:12:0:
.../NdkStandalone/sysroot/usr/include/time.h:101:15: note: previous declaration of 'timegm' was here
 extern time_t timegm(struct tm*) __LIBC_ABI_PUBLIC__;
               ^