### PR TITLE
enable build on openbsd/bitrig

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,10 @@ mod rustrt {
 mod imp {
     use libc::{c_int, timespec};
 
-    // Apparently android provides this in some other library?
     #[cfg(all(not(target_os = "android"),
-              not(target_os = "nacl")))]
+              not(target_os = "bitrig"),
+              not(target_os = "nacl"),
+              not(target_os = "openbsd")))]
     #[link(name = "rt")]
     extern {}
 


### PR DESCRIPTION
sync with rust (src/libstd/sys/unix/time.rs)

openbsd/bitrig provides `clock_gettime` via C library.