### PR TITLE
Do not convert to and from timespec when calling at_utc on a utc Tm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -769,7 +769,10 @@ impl Tm {
 
     /// Convert time to the UTC
     pub fn to_utc(&self) -> Tm {
-        at_utc(self.to_timespec())
+        match self.tm_utcoff {
+            0 => *self,
+            _ => at_utc(self.to_timespec())
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #66 , based on the suggestion by @zslayton