### PR TITLE
Allow colon in timezone specification

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1304,9 +1304,13 @@ mod tests {
         assert!(test_oneway("3",  "%S"));
 
         assert!(strptime("-0000", "%z").unwrap().tm_utcoff == 0);
+        assert!(strptime("-00:00", "%z").unwrap().tm_utcoff == 0);
         assert_eq!(-28800, strptime("-0800", "%z").unwrap().tm_utcoff);
+        assert_eq!(-28800, strptime("-08:00", "%z").unwrap().tm_utcoff);
         assert_eq!(28800, strptime("+0800", "%z").unwrap().tm_utcoff);
+        assert_eq!(28800, strptime("+08:00", "%z").unwrap().tm_utcoff);
         assert_eq!(5400, strptime("+0130", "%z").unwrap().tm_utcoff);
+        assert_eq!(5400, strptime("+01:30", "%z").unwrap().tm_utcoff);
         assert!(test("%", "%%"));
 
         // Test for #7256

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -263,38 +263,21 @@ fn parse_type(s: &mut &str, ch: char, tm: &mut Tm) -> Result<(), ParseError> {
             let mut minutes = 0;
 
             match match_digits(s, 2, 2, false) {
-                Some(h) => {
-                    hours = h;
-                },
-                None => {
-                    failed = true;
-                }
+                Some(h) => hours = h,
+                None => return Err(ParseError::InvalidZoneOffset)
             }
 
-            if !failed {
-                // consume the colon if its present,
-                // just ignore it otherwise
-                match parse_char(s, ':') {
-                    Ok(_) => {}
-                    _ => {}
-                }
+            // consume the colon if its present,
+            // just ignore it otherwise
+            parse_char(s, ':');
 
-                match match_digits(s, 2, 2, false) {
-                    Some(m) => {
-                        minutes = m;
-                    },
-                    None => {
-                        failed = true;
-                    }
-                }
+            match match_digits(s, 2, 2, false) {
+                Some(m) => minutes = m,
+                None => return Err(ParseError::InvalidZoneOffset)   
             }
 
-            if failed {
-                Err(ParseError::InvalidZoneOffset)
-            } else {
-                tm.tm_utcoff = sign * (hours * 60 * 60 + minutes * 60);
-                Ok(())
-            }
+            tm.tm_utcoff = sign * (hours * 60 * 60 + minutes * 60);
+            Ok(())
         }
         '%' => parse_char(s, '%'),
         ch => Err(ParseError::InvalidFormatSpecifier(ch))

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -257,8 +257,7 @@ fn parse_type(s: &mut &str, ch: char, tm: &mut Tm) -> Result<(), ParseError> {
             let sign = if parse_char(s, '+').is_ok() {1}
                        else if parse_char(s, '-').is_ok() {-1}
                        else { return Err(ParseError::InvalidZoneOffset) };
-
-            let mut failed = false;
+                       
             let mut hours = 0;
             let mut minutes = 0;
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -268,7 +268,7 @@ fn parse_type(s: &mut &str, ch: char, tm: &mut Tm) -> Result<(), ParseError> {
 
             // consume the colon if its present,
             // just ignore it otherwise
-            parse_char(s, ':');
+            let _ = parse_char(s, ':');
 
             match match_digits(s, 2, 2, false) {
                 Some(m) => minutes = m,


### PR DESCRIPTION
Fixes #20 

This PR allows (but does not insist) on having colons separating the hours and minutes portion of a timezone specifier.

This PR depends on the strptime leading zeroes support. If that PR doesn't get merged in I can update this one to not depend on it.