### PR TITLE
Allow parsing epoch seconds

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -313,7 +313,7 @@ fn match_strs(ss: &mut &str, strs: &[(&str, i32)]) -> Option<i32> {
 
 fn match_digits(ss: &mut &str, min_digits : usize, max_digits: usize, ws: bool) -> Option<i32> {
     match match_digits_i64(ss, min_digits, max_digits, ws) {
-        Ok(v) => Ok(v as i32),
+        Some(v) => Some(v as i32),
         None => None
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -312,27 +312,9 @@ fn match_strs(ss: &mut &str, strs: &[(&str, i32)]) -> Option<i32> {
 }
 
 fn match_digits(ss: &mut &str, min_digits : usize, max_digits: usize, ws: bool) -> Option<i32> {
-    let mut value = 0;
-    let mut n = 0;
-    if ws {
-        let s2 = ss.trim_left_matches(" ");
-        n = ss.len() - s2.len();
-        if n > max_digits { return None }
-    }
-    let chars = ss[n..].char_indices();
-    for (_, ch) in chars.take(max_digits - n) {
-        match ch {
-            '0' ... '9' => value = value * 10 + (ch as i32 - '0' as i32),
-            _ => break,
-        }
-        n += 1;
-    }
-
-    if n >= min_digits && n <= max_digits {
-        *ss = &ss[n..];
-        Some(value)
-    } else {
-        None
+    match match_digits_i64(ss, min_digits, max_digits, ws) {
+        Ok(v) => Ok(v as i32),
+        None => None
     }
 }
 


### PR DESCRIPTION
Fixes #58 

This PR adds the ability to parse %s format strings. Its a little interesting since %s basically dictates every possible value of the Tm struct, including utc offset, so I just overwrite the working Tm instance with a new Tm from the parsed %s field. Hopefully that is correct!

Once again, this PR depends on the leading zeroes PR. If that doesn't get merged I can redo this one to be independent. Just ignore the first commit if you are looking for changes that are relevant to this PR