### PR TITLE
Clarification of how nsec are used in Timespec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ mod imp {
     }
 }
 
-/// A record specifying a time value in seconds and nanoseconds.
+/// A record specifying a time value in seconds and nanoseconds, where nanoseconds represent the offset from the given second. E.g. a timespec of 1.2 seconds after the beginning of the epoch would be represented as {sec: 1, nsec: 200000000}.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Timespec { pub sec: i64, pub nsec: i32 }


### PR DESCRIPTION
Clarification of how nsec are used in Timespec to represent a time offset. The documentation on this is ambiguous as one could infer a different functioning.