### PR TITLE
Fixes timegm64 runtime linkage error on aarch64 Android.

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -61,9 +61,9 @@ mod inner {
         fn gmtime_r(time_p: *const time_t, result: *mut tm) -> *mut tm;
         fn localtime_r(time_p: *const time_t, result: *mut tm) -> *mut tm;
         fn mktime(tm: *const tm) -> time_t;
-        #[cfg(not(any(target_os = "android", target_os = "nacl")))]
+        #[cfg(not(any(all(target_os = "android", not(target_arch = "aarch64")), target_os = "nacl")))]
         fn timegm(tm: *const tm) -> time_t;
-        #[cfg(target_os = "android")]
+        #[cfg(all(target_os = "android", not(target_arch = "aarch64")))]
         fn timegm64(tm: *const tm) -> time64_t;
     }
 
@@ -115,7 +115,7 @@ mod inner {
     }
 
     pub fn utc_tm_to_time(rust_tm: &Tm) -> i64 {
-        #[cfg(target_os = "android")]
+        #[cfg(all(target_os = "android", not(target_arch = "aarch64")))]
         use self::timegm64 as timegm;
 
         let mut tm = unsafe { mem::zeroed() };


### PR DESCRIPTION
The symbol `timegm64` appears to be missing from the aarch64 android runtime, resulting in runtime linkage errors such as:

```text
java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "timegm64" referenced by ...
```

`__LP64__` is defined for aarch64, meaning the `timegm64` hacks are disabled. The [`time64.h`](https://android.googlesource.com/platform/development/+/797351fd3bbb8fe517afafdd5095fd740387e7a4/ndk/platforms/android-L/include/time64.h) header shows this to be the case.

The patch fixes the runtime linkage issue by only using the `timegm64` hacks for non-aarch64 Androids.